### PR TITLE
Counter public tools

### DIFF
--- a/Confuser.Protections/Constants/ReferenceReplacer.cs
+++ b/Confuser.Protections/Constants/ReferenceReplacer.cs
@@ -25,6 +25,8 @@ namespace Confuser.Protections.Constants {
 				instr.Item1.OpCode = OpCodes.Ldc_I4;
 				instr.Item1.Operand = (int)instr.Item2;
 				method.Body.Instructions.Insert(i + 1, Instruction.Create(OpCodes.Call, instr.Item3));
+                Instruction instr1 = method.Body.Instructions[i + 1];
+                method.Body.Instructions.Insert(i + 1, Instruction.Create(OpCodes.Br_S, instr1));
 			}
 		}
 

--- a/Confuser.Runtime/Constant.cs
+++ b/Confuser.Runtime/Constant.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using System.Reflection;
 
 namespace Confuser.Runtime {
 	internal static class Constant {
@@ -40,31 +41,38 @@ namespace Confuser.Runtime {
 		}
 
 		static T Get<T>(uint id) {
-			id = (uint)Mutation.Placeholder((int)id);
-			uint t = id >> 30;
+            if (Assembly.GetExecutingAssembly() == Assembly.GetCallingAssembly())
+            {
+                id = (uint)Mutation.Placeholder((int)id);
+                uint t = id >> 30;
 
-			T ret = default(T);
-			id &= 0x3fffffff;
-			id <<= 2;
+                T ret = default(T);
+                id &= 0x3fffffff;
+                id <<= 2;
 
-			if (t == Mutation.KeyI0) {
-				int l = b[id++] | (b[id++] << 8) | (b[id++] << 16) | (b[id++] << 24);
-				ret = (T)(object)string.Intern(Encoding.UTF8.GetString(b, (int)id, l));
-			}
-			// NOTE: Assume little-endian
-			else if (t == Mutation.KeyI1) {
-				var v = new T[1];
-				Buffer.BlockCopy(b, (int)id, v, 0, Mutation.Value<int>());
-				ret = v[0];
-			}
-			else if (t == Mutation.KeyI2) {
-				int s = b[id++] | (b[id++] << 8) | (b[id++] << 16) | (b[id++] << 24);
-				int l = b[id++] | (b[id++] << 8) | (b[id++] << 16) | (b[id++] << 24);
-				Array v = Array.CreateInstance(typeof(T).GetElementType(), l);
-				Buffer.BlockCopy(b, (int)id, v, 0, s - 4);
-				ret = (T)(object)v;
-			}
-			return ret;
+                if (t == Mutation.KeyI0)
+                {
+                    int l = b[id++] | (b[id++] << 8) | (b[id++] << 16) | (b[id++] << 24);
+                    ret = (T)(object)string.Intern(Encoding.UTF8.GetString(b, (int)id, l));
+                }
+                // NOTE: Assume little-endian
+                else if (t == Mutation.KeyI1)
+                {
+                    var v = new T[1];
+                    Buffer.BlockCopy(b, (int)id, v, 0, Mutation.Value<int>());
+                    ret = v[0];
+                }
+                else if (t == Mutation.KeyI2)
+                {
+                    int s = b[id++] | (b[id++] << 8) | (b[id++] << 16) | (b[id++] << 24);
+                    int l = b[id++] | (b[id++] << 8) | (b[id++] << 16) | (b[id++] << 24);
+                    Array v = Array.CreateInstance(typeof(T).GetElementType(), l);
+                    Buffer.BlockCopy(b, (int)id, v, 0, s - 4);
+                    ret = (T)(object)v;
+                }
+                return ret;
+            }
+            return default(T);
 		}
 	}
 


### PR DESCRIPTION
Counter ConfuserEx Constants decryptor by CodeCracker and ConfuserEx Static decryptor by Cawk
credits goes to MindSystem.

As both tools checks for 'ldc.i4' before the call, just add an br.s which goes to the call after the ldc.i4.

It will insert a br.s between ldc.i4 and the call, making br.s the instruction before the call.

CodeCracker tool uses Invoke, just add a check to see if the assembly that is executing the code is the same as main assembly.

So to patch it, go to Runtime and add the check.

```csharp
if (Assembly.GetExecutingAssembly() == Assembly.GetCallingAssembly())
{



//code



}
return default(T);