### PR TITLE
Parent process null check

### DIFF
--- a/Confuser.Runtime/AntiDebug.Win32.cs
+++ b/Confuser.Runtime/AntiDebug.Win32.cs
@@ -12,7 +12,7 @@ namespace Confuser.Runtime {
 				Environment.FailFast(null);
             //Anti dnspy
             Process here = GetParentProcess();
-            if (here.ProcessName.ToLower().Contains("dnspy"))
+            if (here != null && here.ProcessName.ToLower().Contains("dnspy"))
                 Environment.FailFast("");
 
             var thread = new Thread(Worker);


### PR DESCRIPTION
Fixed a crash in case the parent process exited.